### PR TITLE
Specific promo screen

### DIFF
--- a/prensa_latas/package-lock.json
+++ b/prensa_latas/package-lock.json
@@ -10640,6 +10640,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
+    "react-loader-spinner": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-3.1.4.tgz",
+      "integrity": "sha512-pl7cvc1eZFwOoUW33BJnuR9TBcAS25SD15RFYecY9ikb8Kv+yFFmaITU6xg001Aw8HsNreAUsrIHozf2fNmIqQ==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-qr-reader": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-2.2.1.tgz",

--- a/prensa_latas/package.json
+++ b/prensa_latas/package.json
@@ -6,8 +6,9 @@
     "axios": "^0.19.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "react-qr-reader": "^2.2.1",
     "react-icons": "^3.7.0",
+    "react-loader-spinner": "^3.1.4",
+    "react-qr-reader": "^2.2.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.2"
   },

--- a/prensa_latas/src/components/Header/index.js
+++ b/prensa_latas/src/components/Header/index.js
@@ -5,7 +5,7 @@ import styles from './style';
 import { FaChevronLeft } from 'react-icons/fa';
 
 class Header extends React.Component {
-    state = {  }
+
     render() {
         return (
             <div style={styles.container}>

--- a/prensa_latas/src/components/Header/index.js
+++ b/prensa_latas/src/components/Header/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import styles from './style';
+
+import { FaChevronLeft } from 'react-icons/fa';
+
+class Header extends React.Component {
+    state = {  }
+    render() {
+        return (
+            <div style={styles.container}>
+                <div
+                    style={styles.icon}
+                    onClick={this.props.action}
+                >
+                    <FaChevronLeft/>
+                </div>
+                <div style={styles.title}>
+                    {this.props.title}
+                </div>
+            </div>
+         );
+    }
+}
+ 
+export default Header;

--- a/prensa_latas/src/components/Header/style.js
+++ b/prensa_latas/src/components/Header/style.js
@@ -1,0 +1,24 @@
+import colors from './../../style/colors';
+
+const style = {
+    container : {
+        width: '100%',
+        height: '60px',
+        background: colors.MidGreen,
+        color: colors.White,
+    },
+    icon : {
+        float: 'left',
+        fontSize: '40px',
+        margin: '10px',
+        position: 'absolute',
+    },
+    title : {
+        textAlign: 'center',
+        lineHeight: '60px',
+        fontSize: '25px',
+        fontWeight: 'regular',
+    }
+}
+
+export default style;

--- a/prensa_latas/src/components/PromoItem/index.js
+++ b/prensa_latas/src/components/PromoItem/index.js
@@ -4,40 +4,15 @@ import styles from './style';
 import colors from './../../style/colors';
 import canIcon from './../../assets/svg/canIcon.svg';
 
+import parseTime from './../../utils/parseTime';
+import styleOfRemain from './../../utils/styleOfRemaining';
+
 export default class PromoItem extends React.Component {
-
-    styleOfRemain(remaining_time) {
-        if (remaining_time.type !== 'd') {
-            return {
-                background: colors.Urgent,
-                color: colors.White,
-            }
-        }
-        if (remaining_time.quantity < 5) {
-            return {
-                background: colors.Warning,
-                color: colors.Black,
-            }
-        }
-        return {
-            background: colors.MidGreen,
-            color: colors.White
-        }
-    }
-
-    parseTimeText(type) {
-        switch (type) {
-            case 'd': return 'dias';
-            case 'h': return 'hrs';
-            case 'm': return 'min';
-            default : return '?';
-        }
-    }
 
     render() {
         let item = this.props.item;
-        let timeLabelStyle = this.styleOfRemain(item.remaining_time);
-        let timeText = this.parseTimeText(item.remaining_time.type);
+        let timeLabelStyle = styleOfRemain(item.remaining_time);
+        let timeText = parseTime(item.remaining_time.type);
 
         return (
             <div style={styles.container}>

--- a/prensa_latas/src/components/PromoItem/index.js
+++ b/prensa_latas/src/components/PromoItem/index.js
@@ -53,11 +53,11 @@ export default class PromoItem extends React.Component {
                     </div>
                     <div style={styles.labelContainer}>
                         <div style={styles.label}>
+                            {item.obtained_score}
                             <img
                                 style={styles.canIcon}
                                 src={canIcon}
                             />
-                            {item.obtained_score}
                         </div>
                         <div
                             style={{

--- a/prensa_latas/src/screens/Promo/SpecificPromo/index.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/index.js
@@ -41,11 +41,14 @@ class SpecificPromo extends React.Component {
                         Termina em
                     </div>
                     <div style={styles.date}>
-                        {'2 ' + timeText}
+                        {item.remaining_time.quantity + ' ' + timeText}
                     </div>
                 </div>
             </div>
-            <div style={styles.backButton}>
+            <div
+                style={styles.backButton}
+                onClick={this.props.backButton}
+            >
                 Voltar
             </div>
             </>

--- a/prensa_latas/src/screens/Promo/SpecificPromo/index.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/index.js
@@ -1,12 +1,18 @@
 import React from 'react';
 
-import canIcon from './../../../assets/svg/canIcon.svg'
-
+import canIcon from './../../../assets/svg/canIcon.svg';
 import styles from './style';
 
+import parseTime from './../../../utils/parseTime';
+import styleOfRemain from './../../../utils/styleOfRemaining';
+
 class SpecificPromo extends React.Component {
+
     render() {
         let item = this.props.item;
+        let timeText = parseTime(item.remaining_time.type);
+        let timeLabelStyle = styleOfRemain(item.remaining_time);
+
         return (
             <>
             <div style={styles.imgContainer}>
@@ -30,12 +36,12 @@ class SpecificPromo extends React.Component {
                     />
                 </div>
                 <div style={styles.whiteBorder}/>
-                <div style={styles.timeColumn}>
+                <div style={{...styles.timeColumn, ...timeLabelStyle}}>
                     <div style={styles.finishOn}>
                         Termina em
                     </div>
                     <div style={styles.date}>
-                        2 dias
+                        {'2 ' + timeText}
                     </div>
                 </div>
             </div>

--- a/prensa_latas/src/screens/Promo/SpecificPromo/index.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/index.js
@@ -18,28 +18,30 @@ class SpecificPromo extends React.Component {
             <div style={styles.description}>
                 {item.description}
             </div>
-            <div>
-                Sua Participação
+            <div style={styles.participation}>
+                Sua participação
             </div>
-            <div>
-                <div>
+            <div style={styles.infoColumns}>
+                <div style={styles.scoreColumn}>
                     {item.obtained_score}
                     <img
+                        style={styles.canIcon}
                         src={canIcon}
                     />
                 </div>
-                <div>
-                    <div>
+                <div style={styles.whiteBorder}/>
+                <div style={styles.timeColumn}>
+                    <div style={styles.finishOn}>
                         Termina em
                     </div>
-                    <div>
-                        {this.parseTime}
+                    <div style={styles.date}>
+                        2 dias
                     </div>
                 </div>
             </div>
-            <div>
+            <button>
                 Voltar
-            </div>
+            </button>
             </>
         );
     }

--- a/prensa_latas/src/screens/Promo/SpecificPromo/index.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/index.js
@@ -39,9 +39,9 @@ class SpecificPromo extends React.Component {
                     </div>
                 </div>
             </div>
-            <button>
+            <div style={styles.backButton}>
                 Voltar
-            </button>
+            </div>
             </>
         );
     }

--- a/prensa_latas/src/screens/Promo/SpecificPromo/index.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import canIcon from './../../../assets/svg/canIcon.svg'
+
+import styles from './style';
+
+class SpecificPromo extends React.Component {
+    render() {
+        let item = this.props.item;
+        return (
+            <>
+            <div style={styles.imgContainer}>
+                <img
+                    style={styles.img}
+                    src={item.img}
+                />
+            </div>
+            <div style={styles.description}>
+                {item.description}
+            </div>
+            <div>
+                Sua Participação
+            </div>
+            <div>
+                <div>
+                    {item.obtained_score}
+                    <img
+                        src={canIcon}
+                    />
+                </div>
+                <div>
+                    <div>
+                        Termina em
+                    </div>
+                    <div>
+                        {this.parseTime}
+                    </div>
+                </div>
+            </div>
+            <div>
+                Voltar
+            </div>
+            </>
+        );
+    }
+}
+ 
+export default SpecificPromo;

--- a/prensa_latas/src/screens/Promo/SpecificPromo/style.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/style.js
@@ -33,7 +33,7 @@ const styles = {
         float: 'left',
         width: '49.5%',
         height: '100%',
-        background: '#afa',
+        background: colors.LightGray,
         fontSize: '45px',
         lineHeight: '90px',
         textAlign: 'center',

--- a/prensa_latas/src/screens/Promo/SpecificPromo/style.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/style.js
@@ -1,3 +1,5 @@
+import colors from './../../../style/colors'
+
 const styles = {
     imgContainer : {
 
@@ -14,6 +16,54 @@ const styles = {
         margin: '15px 25px',
         textAlign: 'center',
         fontSize: '20px'
+    },
+    participation : {
+        textAlign: 'center',
+        fontSize: '30px',
+        margin: '20px auto'
+    },
+    infoColumns : {
+        width: '80vw',
+        height: '90px',
+        margin: '20px auto',
+        borderRadius: '5px',
+        overflow: 'hidden',
+    },
+    scoreColumn : {
+        float: 'left',
+        width: '49.5%',
+        height: '100%',
+        background: '#afa',
+        fontSize: '45px',
+        lineHeight: '90px',
+        textAlign: 'center',
+        fontWeight: 'bold',
+        display: 'inline-block',
+    },
+    canIcon : {
+        height: '45px',
+        margin: '-5px -5px -5px 5px'
+    },
+    whiteBorder : {
+        float: 'left',
+        width: '1%',
+        height: '100%',
+    },
+    timeColumn : {
+        background: colors.MidGreen,
+        color: colors.White,
+        float: 'left',
+        height: '100%',
+        width: '49.5%',
+    },
+    finishOn : {
+        fontSize: '16px',
+        margin: '8px',
+    },
+    date : {
+        fontSize: '32px',
+        textAlign: 'center',
+        fontWeight: 'bold',
     },
 }
 

--- a/prensa_latas/src/screens/Promo/SpecificPromo/style.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/style.js
@@ -1,0 +1,20 @@
+const styles = {
+    imgContainer : {
+
+    },
+    img : {
+        width: '100px',
+        height: '100px',
+        objectFit: 'cover',
+        display: 'block',
+        margin: '30px auto',
+        borderRadius: '5px'
+    },
+    description : {
+        margin: '15px 25px',
+        textAlign: 'center',
+        fontSize: '20px'
+    },
+}
+
+export default styles;

--- a/prensa_latas/src/screens/Promo/SpecificPromo/style.js
+++ b/prensa_latas/src/screens/Promo/SpecificPromo/style.js
@@ -41,8 +41,8 @@ const styles = {
         display: 'inline-block',
     },
     canIcon : {
-        height: '45px',
-        margin: '-5px -5px -5px 5px'
+        height: '70px',
+        margin: '-5px -10px -15px 0px'
     },
     whiteBorder : {
         float: 'left',
@@ -65,6 +65,20 @@ const styles = {
         textAlign: 'center',
         fontWeight: 'bold',
     },
+    backButton : {
+        width: '70vw',
+        maxWidth: '300px',
+        margin: '40px auto',
+        display: 'block',
+        height: '50px',
+        lineHeight: '50px',
+        fontSize: '22px',
+        fontWeight: 'bold',
+        background: colors.MidGreen,
+        color: colors.White,
+        borderRadius: '25px',
+        textAlign: 'center',
+    }
 }
 
 export default styles;

--- a/prensa_latas/src/screens/Promo/index.js
+++ b/prensa_latas/src/screens/Promo/index.js
@@ -61,12 +61,14 @@ export default class PromoScreen extends React.Component {
                     <NavBar selected="PROMO"/>
                 </>
             )
-        } else {            
+        } else {
+            let selected = this.state.promo_list[this.state.selected_promo];
             return(
                 <>
-                <Header title="Promoções" action={this.clearSelection}/>
+                <WaveHeader title={selected.name}/>
                 <SpecificPromo
-                    item={this.state.promo_list[this.state.selected_promo]}
+                    item={selected}
+                    backButton={this.clearSelection}
                 />
                 </>
             )

--- a/prensa_latas/src/screens/Promo/index.js
+++ b/prensa_latas/src/screens/Promo/index.js
@@ -5,6 +5,7 @@ import WaveHeader from './../../components/WaveHeader';
 import Header from './../../components/Header';
 import PromoItem from './../../components/PromoItem';
 import NavBar from './../../components/NavBar';
+import SpecificPromo from './SpecificPromo';
 
 export default class PromoScreen extends React.Component {
 
@@ -22,6 +23,7 @@ export default class PromoScreen extends React.Component {
         axios.get('https://api.myjson.com/bins/7th74')
             .then(response => this.setState({
                 promo_list: response.data,
+                selected_promo: 2,
             }))
     }
 
@@ -51,8 +53,7 @@ export default class PromoScreen extends React.Component {
             )
         })
 
-        if (this.state.selected_promo === null) {
-    
+        if (this.state.selected_promo === null) {  
             return (
                 <>
                     <WaveHeader title="Promoções"/>
@@ -60,11 +61,13 @@ export default class PromoScreen extends React.Component {
                     <NavBar selected="PROMO"/>
                 </>
             )
-        } else {
+        } else {            
             return(
                 <>
                 <Header title="Promoções" action={this.clearSelection}/>
-                {items[this.state.selected_promo]}
+                <SpecificPromo
+                    item={this.state.promo_list[this.state.selected_promo]}
+                />
                 </>
             )
         }

--- a/prensa_latas/src/screens/Promo/index.js
+++ b/prensa_latas/src/screens/Promo/index.js
@@ -2,13 +2,21 @@ import React from 'react';
 import axios from 'axios';
 
 import WaveHeader from './../../components/WaveHeader';
+import Header from './../../components/Header';
 import PromoItem from './../../components/PromoItem';
 import NavBar from './../../components/NavBar';
 
 export default class PromoScreen extends React.Component {
-    state = {
-        promo_list: []
+
+    constructor(props){
+        super(props);
+        this.state = {
+            promo_list: [],
+            selected_promo: null,
+        }
+        this.clearSelection = this.clearSelection.bind(this);
     }
+
 
     componentDidMount() {
         axios.get('https://api.myjson.com/bins/7th74')
@@ -17,24 +25,48 @@ export default class PromoScreen extends React.Component {
             }))
     }
 
+    select(i) {
+        this.setState({
+            selected_promo: i,
+        })
+    }
+
+    clearSelection() {
+        this.setState({
+            selected_promo: null,
+        })
+    }
+
     render() {
         console.log(this.state.promo_list);
 
         let items = this.state.promo_list.map((item, id) => {
             return (
-                <PromoItem
-                    item={item}
-                    key={"item_" + id}
-                />
+                <div onClick={() => {this.select(id)}} key={"divItem_"+id}>
+                    <PromoItem
+                        item={item}
+                        key={"item_" + id}
+                    />
+                </div>
             )
         })
 
-        return (
-            <>
-                <WaveHeader title="Promoções"/>
-                {items}
-                <NavBar selected="PROMO"/>
-            </>
-        )
+        if (this.state.selected_promo === null) {
+    
+            return (
+                <>
+                    <WaveHeader title="Promoções"/>
+                    {items}
+                    <NavBar selected="PROMO"/>
+                </>
+            )
+        } else {
+            return(
+                <>
+                <Header title="Promoções" action={this.clearSelection}/>
+                {items[this.state.selected_promo]}
+                </>
+            )
+        }
     }
 }

--- a/prensa_latas/src/screens/Promo/index.js
+++ b/prensa_latas/src/screens/Promo/index.js
@@ -6,6 +6,10 @@ import Header from './../../components/Header';
 import PromoItem from './../../components/PromoItem';
 import NavBar from './../../components/NavBar';
 import SpecificPromo from './SpecificPromo';
+import Loader from 'react-loader-spinner';
+
+import styles from './style';
+import colors from './../../style/colors';
 
 export default class PromoScreen extends React.Component {
 
@@ -14,6 +18,7 @@ export default class PromoScreen extends React.Component {
         this.state = {
             promo_list: [],
             selected_promo: null,
+            is_loading: true,
         }
         this.clearSelection = this.clearSelection.bind(this);
     }
@@ -23,7 +28,7 @@ export default class PromoScreen extends React.Component {
         axios.get('https://api.myjson.com/bins/7th74')
             .then(response => this.setState({
                 promo_list: response.data,
-                selected_promo: 2,
+                is_loading: false,
             }))
     }
 
@@ -53,11 +58,23 @@ export default class PromoScreen extends React.Component {
             )
         })
 
-        if (this.state.selected_promo === null) {  
+        if (this.state.selected_promo === null) {
+            console.log(styles.loading);
             return (
                 <>
                     <WaveHeader title="Promoções"/>
-                    {items}
+                    {
+                        this.state.is_loading ?
+                            <Loader
+                                style={styles.loading}
+                                type="Grid"
+                                color={colors.MidGreen}
+                                height={100}
+                                width={100}
+                            />
+                        :
+                            items
+                    }
                     <NavBar selected="PROMO"/>
                 </>
             )

--- a/prensa_latas/src/screens/Promo/style.js
+++ b/prensa_latas/src/screens/Promo/style.js
@@ -1,0 +1,10 @@
+const styles = {
+    loading: {
+        margin: '-150px auto',
+        padding: '50vh 0px',
+        height: '100px',
+        width: '100px',
+    },
+}
+
+export default styles;

--- a/prensa_latas/src/utils/parseTime.js
+++ b/prensa_latas/src/utils/parseTime.js
@@ -1,0 +1,10 @@
+function parseTime(type) {
+    switch (type) {
+        case 'd': return 'dias';
+        case 'h': return 'hrs';
+        case 'm': return 'min';
+        default : return '?';
+    }
+}
+
+export default parseTime;

--- a/prensa_latas/src/utils/styleOfRemaining.js
+++ b/prensa_latas/src/utils/styleOfRemaining.js
@@ -1,0 +1,22 @@
+import colors from './../style/colors';
+
+function styleOfRemain(remaining_time) {
+    if (remaining_time.type !== 'd') {
+        return {
+            background: colors.Urgent,
+            color: colors.White,
+        }
+    }
+    if (remaining_time.quantity < 5) {
+        return {
+            background: colors.Warning,
+            color: colors.Black,
+        }
+    }
+    return {
+        background: colors.MidGreen,
+        color: colors.White
+    }
+}
+
+export default styleOfRemain;


### PR DESCRIPTION
## New Screen!
This adds a new screen. "New screen"... So, going to another route seems kinda overhead since all data is already loaded at the previous screen. So I just switch the component that is rendered at the `Promo` screen.

### New logic
It adds some logic at the `Promo` screens that identify which item was selected. The default value to this variable is `null`, and when it's `null`, `Promo` shows the menu of items. Once an item is selected, the component switches to the component that renders the item description. This screen has a back button, click it will reset the select variable to `null`.

### New dependency
[`react-loader-spinner`](https://www.npmjs.com/package/react-loader-spinner) is a npm package that renders a loader.

### Utils folder
`pi2-front/prensa_latas/src/utils` was created to contain some useful things. Actually, it has two `.js` files, each one exporting a function:

- `parseTime(string)`: Receives a time type, may be `d`, `h` or `m` and returns a more meaningful string, like `dias` ou `hrs`. (Yes, Portuguese, we don't have any language manager strategy yet)
- `styleOfRemaining({type: string, quantity: int})`: Return a react style-like object according to the remaining time received.

This actually replaces the similar functions that existed on the `Promo` component, now they're only imported.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/29482983/68029013-112d0300-fc95-11e9-8ae0-b99251fa1bdc.png)

![image](https://user-images.githubusercontent.com/29482983/68029968-2440d280-fc97-11e9-8182-57d63f869b23.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
